### PR TITLE
fix css import with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "stimulus-datepicker",
-  "version": "1.0.7",
+  "name": "calunia-stimulus-datepicker",
+  "version": "1.0.8",
   "description": "StimulusJS datepicker component",
   "author": "Andrew Stewart <boss@airbladesoftware.com>",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stimulus-datepicker",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "StimulusJS datepicker component",
   "author": "Andrew Stewart <boss@airbladesoftware.com>",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "type": "module",
   "main": "src/datepicker.js",
   "source": "src/datepicker.js",
-  "exports": "./src/datepicker.js",
+  "files": [
+    "css/",
+    "src/"
+  ],
+  "style": "css/datepicker.css",
   "license": "MIT",
   "keywords": [
     "stimulus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calunia-stimulus-datepicker",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "StimulusJS datepicker component",
   "author": "Andrew Stewart <boss@airbladesoftware.com>",
   "type": "module",

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -445,7 +445,7 @@ export default class Datepicker extends Controller {
   // @param selected [Number] the selected year
   yearOptions(selected) {
     const years = []
-    const extent = 10
+    const extent = 100
     for (let y = selected - extent; y <= selected + extent; y++) years.push(y)
     return years
       .map(year => `<option ${year == selected ? 'selected' : ''}>${year}</option>`)

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -110,7 +110,7 @@ export default class Datepicker extends Controller {
 
   update() {
     const dateStr = this.parse(this.inputTarget.value)
-    if (dateStr != '') this.dateValue = dateStr
+    this.dateValue = dateStr
   }
 
   toggle(event) {


### PR DESCRIPTION
Hello,
Actually, when i try to import the css with webpack encore, i got the error :
`Module not found: Error: Package path ./css/datepicker.css is not exported from package node_modules/stimulus-datepicker (see exports field in node_modules/stimulus-datepicker/package.json)`

Change
` "exports": "./src/datepicker.js", `

to 
```
"files": [
    "css/",
    "src/"
  ],
```
Fix this issue for me but i don't know how i can run your tests :/
So i open this pr if it can help someone :)
Thx Calunia