### PR TITLE
fix: do not trigger input change callback on init

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -45,11 +45,12 @@ export default class Datepicker extends Controller {
 
   dateValueChanged(value, previousValue) {
     if (!this.hasHiddenTarget) return
+    const dispatchChangeEvent = value != this.hiddenTarget.value;
     this.hiddenTarget.value = value
     this.inputTarget.value = this.format(value)
     // Trigger change event on input when user selects date from picker.
     // http://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
-    if (value != previousValue) this.inputTarget.dispatchEvent(new Event('change'))
+    if (dispatchChangeEvent) this.inputTarget.dispatchEvent(new Event('change'))
     this.validate(value)
   }
 
@@ -79,6 +80,7 @@ export default class Datepicker extends Controller {
     this.inputTarget.insertAdjacentHTML('afterend', `
       <input type="hidden"
              name="${this.inputTarget.getAttribute('name')}"
+             value="${this.inputTarget.value}"
              data-datepicker-target="hidden"/>
     `)
   }


### PR DESCRIPTION
When the value is set on the input, the `change` callback gets triggered immediately after mount.

example markup:

```
    <input data-datepicker-target="input"
           type="text"
           value="2023-01-01"
           data-action="change->example_controller#this_triggers_immediately"
    />
```

From my point of view the expected behaviour would be to trigger the callback only after the first _actual_ change - e.g. after user selects a new date.

I've prepared following fix locally, where the behaviour is as expected. 
The code is very ugly though & there're no tests for it. 
Unfortunately I don't have enough time to do the proper implementation now. I might get back to it later.

If you find it useful, feel free to use/adjust it. Otherwise feel free to close the MR.